### PR TITLE
Allow use of newer riscv-none-elf- cross toolchains

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,11 @@
 TOOL_CHAIN_PATH ?= /opt/gcc-riscv/riscv-none-embed-gcc-10.2.0-1.2/bin
+CROSS=riscv-none-embed-
+ARCH=rv32imac
+# Comment out above and enable below for gcc 13.2:
+#TOOL_CHAIN_PATH ?= /opt/gcc-riscv/riscv-none-elf-gcc-13.2.0-2/bin
+#CROSS=riscv-none-elf-
+#ARCH=rv32imac_zicsr
+
 OPENOCD_PATH    ?= /opt/openocd/wch-openocd/bin
 PROJECT_NAME    = app
 
@@ -24,7 +31,7 @@ INCLUDES += -I $(TOP_DIR)/Core
 INCLUDES += -I $(TOP_DIR)/Debug
 INCLUDES += -I $(TOP_DIR)/Peripheral/inc
 
-CCFLAGS := -march=rv32imac \
+CCFLAGS := -march=$(ARCH) \
            -mabi=ilp32 \
            -msmall-data-limit=8 \
            -mno-save-restore \
@@ -55,35 +62,35 @@ USER_OBJS := $(patsubst $(USER_DIR)/%.c, $(OUTPUT_DIR)/user/%.o, $(USER_SRCS))
 
 $(OUTPUT_DIR)/startup/%.o: $(STARTUP_DIR)/%.S
 	@mkdir -p $(@D)
-	$(TOOL_CHAIN_PATH)/riscv-none-embed-gcc $(CCFLAGS) -x assembler -MMD -MP -MF"$(@:%.o=%.d)" -MT"$(@)" -c -o "$@" "$<"
+	$(TOOL_CHAIN_PATH)/$(CROSS)gcc $(CCFLAGS) -x assembler -MMD -MP -MF"$(@:%.o=%.d)" -MT"$(@)" -c -o "$@" "$<"
 
 $(OUTPUT_DIR)/core/%.o: $(CORE_DIR)/%.c
 	@mkdir -p $(@D)
-	$(TOOL_CHAIN_PATH)/riscv-none-embed-gcc $(CCFLAGS) $(INCLUDES) -std=gnu99 -MMD -MP -MF"$(@:%.o=%.d)" -MT"$(@)" -c -o "$@" "$<"
+	$(TOOL_CHAIN_PATH)/$(CROSS)gcc $(CCFLAGS) $(INCLUDES) -std=gnu99 -MMD -MP -MF"$(@:%.o=%.d)" -MT"$(@)" -c -o "$@" "$<"
 
 $(OUTPUT_DIR)/debug/%.o: $(DEBUG_DIR)/%.c
 	@mkdir -p $(@D)
-	$(TOOL_CHAIN_PATH)/riscv-none-embed-gcc $(CCFLAGS) $(INCLUDES) -std=gnu99 -MMD -MP -MF"$(@:%.o=%.d)" -MT"$(@)" -c -o "$@" "$<"
+	$(TOOL_CHAIN_PATH)/$(CROSS)gcc $(CCFLAGS) $(INCLUDES) -std=gnu99 -MMD -MP -MF"$(@:%.o=%.d)" -MT"$(@)" -c -o "$@" "$<"
 
 $(OUTPUT_DIR)/spl/%.o: $(SPL_DIR)/src/%.c
 	@mkdir -p $(@D)
-	$(TOOL_CHAIN_PATH)/riscv-none-embed-gcc $(CCFLAGS) $(INCLUDES) -std=gnu99 -MMD -MP -MF"$(@:%.o=%.d)" -MT"$(@)" -c -o "$@" "$<"
+	$(TOOL_CHAIN_PATH)/$(CROSS)gcc $(CCFLAGS) $(INCLUDES) -std=gnu99 -MMD -MP -MF"$(@:%.o=%.d)" -MT"$(@)" -c -o "$@" "$<"
 
 $(OUTPUT_DIR)/user/%.o: $(USER_DIR)/%.c
 	@mkdir -p $(@D)
-	$(TOOL_CHAIN_PATH)/riscv-none-embed-gcc $(CCFLAGS) $(INCLUDES) -std=gnu99 -MMD -MP -MF"$(@:%.o=%.d)" -MT"$(@)" -c -o "$@" "$<"
+	$(TOOL_CHAIN_PATH)/$(CROSS)gcc $(CCFLAGS) $(INCLUDES) -std=gnu99 -MMD -MP -MF"$(@:%.o=%.d)" -MT"$(@)" -c -o "$@" "$<"
 
 $(ELF_FILE): $(STARTUP_OBJS) $(CORE_OBJS) $(DEBUG_OBJS) $(SPL_OBJS) $(USER_OBJS)
-	$(TOOL_CHAIN_PATH)/riscv-none-embed-gcc $(CCFLAGS) -T $(LD_FILE) -nostartfiles -Xlinker --gc-sections -Wl,-Map,$(MAP_FILE) --specs=nano.specs --specs=nosys.specs -o $(ELF_FILE) $(USER_OBJS) $(STARTUP_OBJS) $(CORE_OBJS) $(DEBUG_OBJS) $(SPL_OBJS)
+	$(TOOL_CHAIN_PATH)/$(CROSS)gcc $(CCFLAGS) -T $(LD_FILE) -nostartfiles -Xlinker --gc-sections -Wl,-Map,$(MAP_FILE) --specs=nano.specs --specs=nosys.specs -o $(ELF_FILE) $(USER_OBJS) $(STARTUP_OBJS) $(CORE_OBJS) $(DEBUG_OBJS) $(SPL_OBJS)
 
 $(HEX_FILE): $(ELF_FILE)
-	$(TOOL_CHAIN_PATH)/riscv-none-embed-objcopy -O ihex $(ELF_FILE) $(HEX_FILE)
+	$(TOOL_CHAIN_PATH)/$(CROSS)objcopy -O ihex $(ELF_FILE) $(HEX_FILE)
 
 $(LST_FILE): $(ELF_FILE)
-	$(TOOL_CHAIN_PATH)/riscv-none-embed-objdump --all-headers --demangle --disassemble $(ELF_FILE) > $(LST_FILE)
+	$(TOOL_CHAIN_PATH)/$(CROSS)objdump --all-headers --demangle --disassemble $(ELF_FILE) > $(LST_FILE)
 
 $(SIZ_FILE): $(ELF_FILE)
-	$(TOOL_CHAIN_PATH)/riscv-none-embed-size --format=berkeley $(ELF_FILE)
+	$(TOOL_CHAIN_PATH)/$(CROSS)size --format=berkeley $(ELF_FILE)
 
 
 .PHONY: clean


### PR DESCRIPTION
The hard coded riscv-none-embed- toolchain is deprecated. Allow
selection of the newer riscv-none-elf- toolchains.